### PR TITLE
Upgrade to Orchard Core RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 mono: none
 dist: bionic
-dotnet: 2.2.100
+dotnet: 3.0
 
 install:
 - dotnet restore

--- a/Etch.OrchardCore.InjectScripts.csproj
+++ b/Etch.OrchardCore.InjectScripts.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.1.0-beta</Version>
+    <Version>0.2.0-rc1</Version>
     <PackageId>Etch.OrchardCore.InjectScripts</PackageId>
     <Title>Inject Scripts</Title>
     <Authors>Etch</Authors>
@@ -12,15 +13,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.Admin.Abstractions" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.Navigation" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.ResourceManagement" Version="1.0.0-beta3-71077" />
+    <PackageReference Include="OrchardCore.Admin.Abstractions" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Navigation" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.ResourceManagement" Version="1.0.0-rc1-10004" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>

--- a/Permissions.cs
+++ b/Permissions.cs
@@ -1,5 +1,7 @@
 ﻿using OrchardCore.Security.Permissions;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Etch.OrchardCore.InjectScripts
 {
@@ -7,9 +9,9 @@ namespace Etch.OrchardCore.InjectScripts
     {
         public static readonly Permission ManageInjectScripts = new Permission("InjectScipts", "Manage Inject Scripts");
 
-        public IEnumerable<Permission> GetPermissions()
+        public Task<IEnumerable<Permission>> GetPermissionsAsync()
         {
-            return new[] { ManageInjectScripts };
+            return Task.FromResult(new[] { ManageInjectScripts }.AsEnumerable());
         }
 
         public IEnumerable<PermissionStereotype> GetDefaultStereotypes()

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Module for [Orchard Core](https://github.com/OrchardCMS/OrchardCore) that allows
 
 ## Orchard Core Reference
 
-This module is referencing the beta 3 build of Orchard Core ([`1.0.0-beta3-71077`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-beta3-71077)).
+This module is referencing the RC1 build of Orchard Core ([`1.0.0-rc1-10004`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-rc1-10004)).
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ This module is referencing the beta 3 build of Orchard Core ([`1.0.0-beta3-71077
 
 ## Installing
 
-This module is [available on NuGet](https://www.nuget.org/packages/Etch.OrchardCore.InjectScripts). Add a reference to your Orchard Core web project via the NuGet package manager. Search for "Etch.OrchardCore.Fields", ensuring include prereleases is checked.
+This module is [available on NuGet](https://www.nuget.org/packages/Etch.OrchardCore.InjectScripts). Add a reference to your Orchard Core web project via the NuGet package manager. Search for "Etch.OrchardCore.InjectScripts", ensuring include prereleases is checked.
 
 Alternatively you can [download the source](https://github.com/etchuk/Etch.OrchardCore.InjectScripts/archive/master.zip) or clone the repository to your local machine. Add the project to your solution that contains an Orchard Core project and add a reference to Etch.OrchardCore.InjectScripts.

--- a/azure-pipeline-prerelease.yml
+++ b/azure-pipeline-prerelease.yml
@@ -1,5 +1,6 @@
 pool:
-  name: Hosted VS2017
+  vmImage: 'windows-2019'
+
 variables:
   BuildConfiguration: 'Release'
 
@@ -18,8 +19,10 @@ steps:
   displayName: 'dotnet pack'
   inputs:
     command: pack
-    versioningScheme: byEnvVar
-    versionEnvVar: 'VERSION_MAJORMINORPATCH'
+    versioningScheme: byPrereleaseNumber
+    majorVersion: '$(Version.Major)'
+    minorVersion: '$(Version.Minor)'
+    patchVersion: '$(Version.Patch)'
 
 - task: PublishPipelineArtifact@0
   displayName: 'Publish Pipeline Artifact'

--- a/azure-pipeline-stable.yml
+++ b/azure-pipeline-stable.yml
@@ -1,5 +1,5 @@
 pool:
-  name: Hosted VS2017
+  vmImage: 'windows-2019'
 
 variables:
   BuildConfiguration: 'Release'
@@ -19,10 +19,8 @@ steps:
   displayName: 'dotnet pack'
   inputs:
     command: pack
-    versioningScheme: byPrereleaseNumber
-    majorVersion: '$(Version.Major)'
-    minorVersion: '$(Version.Minor)'
-    patchVersion: '$(Version.Patch)'
+    versioningScheme: byEnvVar
+    versionEnvVar: 'VERSION_MAJORMINORPATCH'
 
 - task: PublishPipelineArtifact@0
   displayName: 'Publish Pipeline Artifact'


### PR DESCRIPTION
- Change target framework to .NET core 3.0
- Add AddRazorSupportForMvc to signify class library contains UI
components for MVC
- Update all Orchard Core dependencies to point to rc1 release
- Swap Microsoft.AspNetCore references for FrameworkReference
- Update permission providers to be async
- Rename Azure pipeline build files as per other modules
- Update Azure pipeline to use .NET core 3.0
- Update Travis build script to use .NET core 3.0
- Update docs for Orchard Core reference
- Bump version number and update suffix to "rc1"